### PR TITLE
Let jQuery set the class of buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a dated means of dependency management, however, until all COINS tools m
 run `npm run demo` and open the posted url!  `demo/index.html` should load with some helpful examples.
 
 ## changelog
-- 2.0.1/2/3 - fulfill 2.0.0 claim
+- 2.0.1/2 - fulfill 2.0.0 claim
 - 2.0.0 - `require` jquery and lodash individually. only consumed lodash fns are required into bundle
 - 1.1.1 - Force close handlers before destroy
 - 1.1.0 - Added destroy button and default dialog closing to destroy

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a dated means of dependency management, however, until all COINS tools m
 run `npm run demo` and open the posted url!  `demo/index.html` should load with some helpful examples.
 
 ## changelog
-- 2.0.1/2 - fulfill 2.0.0 claim
+- 2.0.1/2/3 - fulfill 2.0.0 claim
 - 2.0.0 - `require` jquery and lodash individually. only consumed lodash fns are required into bundle
 - 1.1.1 - Force close handlers before destroy
 - 1.1.0 - Added destroy button and default dialog closing to destroy

--- a/lib/button.js
+++ b/lib/button.js
@@ -82,9 +82,9 @@ button.base = function(options) {
 
 
     if (el) {
-        el.className += options.class;
-        delete options.class;
         $el = jQuery(el);
+        $el.addClass(options.class);
+        delete options.class;
     }
 
     if (returnConfig || !el) {

--- a/lib/button.js
+++ b/lib/button.js
@@ -77,14 +77,21 @@ button.base = function(options) {
         if (closeDialog) { jQuery(this).dialog("close"); }
         if (destroyDialog) { jQuery(this).dialog("destroy"); }
     };
-    options.classes = (options.class && button.btnClasses[options.class]) ?
+    options.class = (options.class && button.btnClasses[options.class]) ?
         button.btnClasses[options.class] : button.btnClasses["default"];
+
+
+    if (el) {
+        el.className += options.class;
+        delete options.class;
+        $el = jQuery(el);
+    }
 
     if (returnConfig || !el) {
         return options;
     }
 
-    $el = jQuery(el).button(options);
+    $el = $el.button(options);
     $el.on('click', options.click);
     return $el;
 };

--- a/lib/button.js
+++ b/lib/button.js
@@ -77,21 +77,14 @@ button.base = function(options) {
         if (closeDialog) { jQuery(this).dialog("close"); }
         if (destroyDialog) { jQuery(this).dialog("destroy"); }
     };
-    options.class = (options.class && button.btnClasses[options.class]) ?
+    options.classes = (options.class && button.btnClasses[options.class]) ?
         button.btnClasses[options.class] : button.btnClasses["default"];
-
-
-    if (el) {
-        el.className += options.class;
-        delete options.class;
-        $el = jQuery(el);
-    }
 
     if (returnConfig || !el) {
         return options;
     }
 
-    $el = $el.button(options);
+    $el = jQuery(el).button(options);
     $el.on('click', options.click);
     return $el;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coins-jquery-ui-utilities",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Common GUI actions and objects, standardized and simplified for constructing jQ UI widget instances",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coins-jquery-ui-utilities",
-  "version": "2.0.3",
+  "version": "2.0.2",
   "description": "Common GUI actions and objects, standardized and simplified for constructing jQ UI widget instances",
   "main": "index.js",
   "scripts": {
@@ -29,8 +29,8 @@
     "testem": "^0.7.5"
   },
   "dependencies": {
-    "jquery-ui": "*",
-    "jquery": "*",
-    "lodash": "*"
+    "jquery-ui": "^1.10.5",
+    "jquery": "^2.1.4",
+    "lodash": "^3.9.3"
   }
 }


### PR DESCRIPTION
# Problem

Button class was set before jQuery.button() initialization which overrides manually set class names. 
# Solution

Use jQuery's built-in `classes` option.
