### PR TITLE
Pass event object to handler scope

### DIFF
--- a/lib/button.js
+++ b/lib/button.js
@@ -71,7 +71,7 @@ button.base = function(options) {
     delete options.click;
 
     // retain original click func, but overwrite with extended version
-    options.click = function() {
+    options.click = function(event) {
         if (click) { click.call(this.el); }
         if (action) { execAction(action); }
         if (closeDialog) { jQuery(this).dialog("close"); }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coins-jquery-ui-utilities",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Common GUI actions and objects, standardized and simplified for constructing jQ UI widget instances",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is helpful when the handler is applied to multiple elements and some action is intended for only the clicked element. 